### PR TITLE
feat: Bump Perses to 0.48.0 by default

### DIFF
--- a/charts/perses/Chart.yaml
+++ b/charts/perses/Chart.yaml
@@ -3,8 +3,8 @@ name: perses
 description: Perses helm chart
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.4.1
-appVersion: "v0.47.1"
+version: 0.4.2
+appVersion: "v0.48.0"
 sources:
   - https://github.com/perses/perses
 annotations:

--- a/charts/perses/README.md
+++ b/charts/perses/README.md
@@ -4,7 +4,7 @@
 
 Perses helm chart
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.47.1](https://img.shields.io/badge/AppVersion-v0.47.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.48.0](https://img.shields.io/badge/AppVersion-v0.48.0-informational?style=flat-square)
 
 ## Installing the Chart
 


### PR DESCRIPTION
# Description

Bump Perses version to 0.48.0 and update the Helm chart version to 0.4.2. Generated the README accordingly.

Resolve: #23

## Reviewer Hint

The configuration changes introduced in 0.48.0 are related to authentication providers which aren't supported in 0.4.1 yet.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
