### PR TITLE
[BUGFIX] checksum/config already defined

### DIFF
--- a/charts/perses/templates/statefulset.yaml
+++ b/charts/perses/templates/statefulset.yaml
@@ -20,9 +20,10 @@ spec:
       labels:
         {{- include "perses.selectorLabels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- if .Values.datasources }}
         checksum/config: {{ include (print $.Template.BasePath "/datasources.yaml") . | sha256sum }}
+        {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "perses.serviceAccountName" . }}


### PR DESCRIPTION
This fixes:

```
Helm install failed for release prom/perses with chart perses@0.4.2: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 30: mapping key "checksum/config" already defined at line 29
```

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
