### PR TITLE
Fix: Add SecurityContext to StatefulSet when Persistence is Enabled

### DIFF
--- a/charts/perses/templates/pvc.yaml
+++ b/charts/perses/templates/pvc.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass }}
+{{- end }}
   accessModes:
   {{- range .Values.persistence.accessModes }}
     - {{ . | quote }}

--- a/charts/perses/templates/statefulset.yaml
+++ b/charts/perses/templates/statefulset.yaml
@@ -26,10 +26,8 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "perses.serviceAccountName" . }}
-      {{- if .Values.persistence.enabled }}
       securityContext:
         {{- toYaml .Values.persistence.securityContext | nindent 8 }}
-      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.name }}:{{ .Values.image.version | default .Chart.AppVersion }}"

--- a/charts/perses/templates/statefulset.yaml
+++ b/charts/perses/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "perses.serviceAccountName" . }}
+      {{- if .Values.persistence.enabled }}
+      securityContext:
+        {{- toYaml .Values.persistence.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.name }}:{{ .Values.image.version | default .Chart.AppVersion }}"

--- a/charts/perses/values.schema.json
+++ b/charts/perses/values.schema.json
@@ -411,6 +411,15 @@
         "size": {
           "type": "string"
         },
+        "securityContext":{
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fsGroup": {
+              "type": "integer"
+            }
+          }
+        },
         "labels": {
           "type": "object"
         },

--- a/charts/perses/values.schema.json
+++ b/charts/perses/values.schema.json
@@ -430,8 +430,7 @@
       "required": [
         "accessModes",
         "enabled",
-        "size",
-        "storageClass"
+        "size"
       ]
     },
     "livenessProbe": {

--- a/charts/perses/values.yaml
+++ b/charts/perses/values.yaml
@@ -149,8 +149,8 @@ persistence:
   # -- If disabled, it will use a emptydir volume
   enabled: false
 
-  # -- Specify the `storageClass` used to provision the volume
-  storageClass: "default"
+  # -- Specify the `storageClass` to provision the volume for the PVC. If you don't specify a `storageClass`, a default `storageClass` will be used.
+  # storageClass: ""
 
   # -- PVC Access Modes for data volume
   accessModes:

--- a/charts/perses/values.yaml
+++ b/charts/perses/values.yaml
@@ -207,4 +207,4 @@ datasources:
   #       kind: PrometheusDatasource
   #       spec:
   #         directUrl: https://prometheus.demo.do.prometheus.io
-  
+

--- a/charts/perses/values.yaml
+++ b/charts/perses/values.yaml
@@ -207,4 +207,3 @@ datasources:
   #       kind: PrometheusDatasource
   #       spec:
   #         directUrl: https://prometheus.demo.do.prometheus.io
-

--- a/charts/perses/values.yaml
+++ b/charts/perses/values.yaml
@@ -150,7 +150,7 @@ persistence:
   enabled: false
 
   # -- Specify the `storageClass` used to provision the volume
-  storageClass: ""
+  storageClass: "default"
 
   # -- PVC Access Modes for data volume
   accessModes:
@@ -158,6 +158,10 @@ persistence:
 
   # -- PVC Storage Request for data volume
   size: 8Gi
+
+  # -- Security context for the PVC when persistence is enabled
+  securityContext:
+    fsGroup: 2000
 
   # -- Labels for the PVC
   labels: {}

--- a/charts/perses/values.yaml
+++ b/charts/perses/values.yaml
@@ -207,3 +207,4 @@ datasources:
   #       kind: PrometheusDatasource
   #       spec:
   #         directUrl: https://prometheus.demo.do.prometheus.io
+  


### PR DESCRIPTION
This PR resolves a permission issue when persistence.enabled: true in the Helm chart. The Perses StatefulSet was unable to write to the /perses/globaldatasources directory due to missing permissions on the mounted volume.

fixes #27 