### PR TITLE
[ENHANCEMENT] Add global property to schema to enable Perses as a dependent Chart

### DIFF
--- a/charts/perses/Chart.yaml
+++ b/charts/perses/Chart.yaml
@@ -3,7 +3,7 @@ name: perses
 description: Perses helm chart
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: "v0.49.0"
 sources:
   - https://github.com/perses/perses

--- a/charts/perses/README.md
+++ b/charts/perses/README.md
@@ -4,7 +4,7 @@
 
 Perses helm chart
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.49.0](https://img.shields.io/badge/AppVersion-v0.49.0-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.49.0](https://img.shields.io/badge/AppVersion-v0.49.0-informational?style=flat-square)
 
 ## Installing the Chart
 

--- a/charts/perses/values.schema.json
+++ b/charts/perses/values.schema.json
@@ -4,6 +4,11 @@
   "title": "Values",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global values applied to all resources.",
+      "default": {}
+    },
     "nameOverride": {
       "description": "Override name of the chart used in Kubernetes object names.",
       "type": "string"


### PR DESCRIPTION
**Description:**
This PR adds the `global` property to the schema to enable using the chart as a [Dependent Chart](https://helm.sh/docs/helm/helm_dependency/). This addresses a known Helm limitation (helm/helm#10392) that prevents charts from being used as dependent charts when the global property is not defined in the `values.schema.json`.

**Error encountered in our perses wrapper chart:**
```
Error: values don't meet the specifications of the schema(s):
- (root): Additional property global is not allowed
```

**Changes:**
- Add global property to values.schema.json
- Follows the pattern used by other major charts (cert-manager, opentelemetry-operator)