### PR TITLE
DOC:  Update Makefile command for Perses chart docs generation

### DIFF
--- a/.github/workflows/update-on-version.yml
+++ b/.github/workflows/update-on-version.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Generate documentation and assets
         if: steps.version-update.outputs.version_changed == 'true'
-        run: make
+        run: make update-helm-readme
 
       - name: Commit and push changes
         if: steps.version-update.outputs.version_changed == 'true'


### PR DESCRIPTION
This PR fixes the automatic README generation for the Perses Helm chart. It corrects the Makefile command that generates `charts/perses/README.md` from its template file `charts/perses/README.md.gotmpl`