### PR TITLE
[ENHANCEMENT]: configure the correct heatlh endpoint for liveness and readiness probes

### DIFF
--- a/charts/perses/Chart.yaml
+++ b/charts/perses/Chart.yaml
@@ -3,7 +3,7 @@ name: perses
 description: Perses helm chart
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: "v0.52.0"
 sources:
   - https://github.com/perses/perses

--- a/charts/perses/templates/deployment.yaml
+++ b/charts/perses/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
           containerPort: {{ .Values.service.targetPort}}
         readinessProbe:
           httpGet:
-            path: {{ .Values.config.api_prefix }}/metrics
+            path: {{ .Values.config.api_prefix }}/api/v1/health
             port: http
             scheme: HTTP
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -119,7 +119,7 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.config.api_prefix }}/metrics
+            path: {{ .Values.config.api_prefix }}/api/v1/health
             port: http
             scheme: HTTP
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}

--- a/charts/perses/templates/statefulset.yaml
+++ b/charts/perses/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
             containerPort: {{ .Values.service.targetPort }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.config.api_prefix }}/metrics
+            path: {{ .Values.config.api_prefix }}/api/v1/health
             port: http
             scheme: HTTP
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -137,7 +137,7 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.config.api_prefix }}/metrics
+            path: {{ .Values.config.api_prefix }}/api/v1/health
             port: http
             scheme: HTTP
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}


### PR DESCRIPTION
Update the health check endpoints for liveness and readiness probes to use the correct health API path.
