### PR TITLE
[BUGFIX](perses-operator) Make cert-manager volume conditional

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -40,6 +40,14 @@ jobs:
         with:
           enable_go: true
 
+      # Test perses-operator without cert-manager (certManager.enable=false)
+      - name: test perses-operator without cert-manager
+        run: |
+          helm install perses-operator-no-cm charts/perses-operator \
+            --set certManager.enable=false --wait --timeout 120s
+          helm test perses-operator-no-cm
+          helm uninstall perses-operator-no-cm --wait
+
       # perses-operator chart requires cert-manager for webhook and metrics TLS certificates
       - name: install cert-manager
         run: |

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,6 +47,7 @@ jobs:
             --set certManager.enable=false --wait --timeout 120s
           helm test perses-operator-no-cm
           helm uninstall perses-operator-no-cm --wait
+          kubectl delete crd -l app.kubernetes.io/managed-by=Helm --ignore-not-found
 
       # perses-operator chart requires cert-manager for webhook and metrics TLS certificates
       - name: install cert-manager

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ kind-delete: ## Delete the kind cluster.
 	@kind delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: helm-local-install
-helm-local-install: helm ## Install charts locally. Use CHART=charts/<name> to install a single chart.
+helm-local-install: helm ## Install charts locally. Use CHART=charts/<name> and HELM_EXTRA_ARGS="--set key=val" for overrides.
 	@for chart in $(or $(CHART),$(CHARTS)); do \
 		release=$$(basename $$chart); \
 		echo ">> installing $$chart as $$release"; \
-		$(HELM) install $$release $$chart --wait --timeout 120s; \
+		$(HELM) install $$release $$chart --wait --timeout 120s $(HELM_EXTRA_ARGS); \
 	done
 
 .PHONY: helm-local-uninstall

--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ For detailed configuration options, see the [Perses chart documentation](./chart
 
 This chart deploys the [Perses Operator](https://github.com/perses/perses-operator) on Kubernetes. It installs the operator along with CRDs, RBAC, cert-manager integration, and webhook configuration to manage Perses instances, dashboards, and data sources declaratively via custom resources.
 
-Install the Perses Operator:
+By default, the chart requires [cert-manager](https://cert-manager.io/docs/installation/) to be installed in the cluster for webhook and metrics TLS certificates.
+
+Install the Perses Operator with default configuration (requires cert-manager):
 
 ```console
 helm install perses-operator perses/perses-operator
+```
+
+To install without cert-manager (not recommended for production):
+
+```console
+helm install perses-operator perses/perses-operator --set certManager.enable=false
 ```
 
 For detailed configuration options, see the [Perses Operator chart documentation](./charts/perses-operator/README.md).

--- a/charts/perses-operator/CHANGELOG.md
+++ b/charts/perses-operator/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to the perses-operator Helm chart will be documented in this file.
+
+## [0.1.1]
+
+### Fixed
+
+- Chart fails to install when `certManager.enable=false` due to unconditional cert volume and volumeMounts in the manager deployment.
+
+### Added
+
+- `values.schema.json` for Helm values validation and Artifact Hub schema display.
+- CI and unit test coverage for `certManager.enable=false`.
+- Documentation for installing without cert-manager in README.
+
+### Changed
+
+- Webhook cert volume and volumeMounts are now conditional on `certManager.enable`.
+
+## [0.1.0]
+
+- Initial chart release.

--- a/charts/perses-operator/Chart.yaml
+++ b/charts/perses-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Perses Operator - manages Perses instances and
 icon: https://raw.githubusercontent.com/perses/perses-operator/main/docs/logos/perses-operator-logo.png
 type: application
 
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.2.0"
 
 home: https://github.com/perses/perses-operator

--- a/charts/perses-operator/README.md
+++ b/charts/perses-operator/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Perses Operator - manages Perses instances and dashboards on Kubernetes
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/perses-operator/README.md
+++ b/charts/perses-operator/README.md
@@ -10,17 +10,25 @@ A Helm chart for the Perses Operator - manages Perses instances and dashboards o
 
 - Kubernetes 1.26+
 - Helm 3.x
-- [cert-manager](https://cert-manager.io/) installed in the cluster (required for webhook and metrics TLS certificates)
+- [cert-manager](https://cert-manager.io/) installed in the cluster (required when `certManager.enable=true`, which is the default)
 
 ## Installing the Chart
 
-To install the chart with the release name `perses-operator`:
+To install the chart with the release name `perses-operator` (requires cert-manager):
 
 ```bash
 helm repo add perses https://perses.github.io/helm-charts
 helm repo update
 helm install perses-operator perses/perses-operator
 ```
+
+To install without cert-manager (not recommended for production):
+
+```bash
+helm install perses-operator perses/perses-operator --set certManager.enable=false
+```
+
+> **Note:** Disabling cert-manager means TLS certificates for webhooks and metrics will not be automatically provisioned. This is suitable for development and testing but not recommended for production. You will need to manage certificates externally if required.
 
 ## Uninstalling the Chart
 

--- a/charts/perses-operator/README.md.gotmpl
+++ b/charts/perses-operator/README.md.gotmpl
@@ -9,17 +9,25 @@
 
 - Kubernetes 1.26+
 - Helm 3.x
-- [cert-manager](https://cert-manager.io/) installed in the cluster (required for webhook and metrics TLS certificates)
+- [cert-manager](https://cert-manager.io/) installed in the cluster (required when `certManager.enable=true`, which is the default)
 
 ## Installing the Chart
 
-To install the chart with the release name `perses-operator`:
+To install the chart with the release name `perses-operator` (requires cert-manager):
 
 ```bash
 helm repo add perses https://perses.github.io/helm-charts
 helm repo update
 helm install perses-operator perses/perses-operator
 ```
+
+To install without cert-manager (not recommended for production):
+
+```bash
+helm install perses-operator perses/perses-operator --set certManager.enable=false
+```
+
+> **Note:** Disabling cert-manager means TLS certificates for webhooks and metrics will not be automatically provisioned. This is suitable for development and testing but not recommended for production. You will need to manage certificates externally if required.
 
 ## Uninstalling the Chart
 

--- a/charts/perses-operator/templates/manager/manager.yaml
+++ b/charts/perses-operator/templates/manager/manager.yaml
@@ -85,10 +85,12 @@ spec:
                     {{- else }}
                     {}
                     {{- end }}
+                  {{- if .Values.certManager.enable }}
                   volumeMounts:
                     - mountPath: /tmp/k8s-webhook-server/serving-certs
                       name: cert
                       readOnly: true
+                  {{- end }}
                 - args:
                     - --secure-listen-address=0.0.0.0:8443
                     - --upstream=http://127.0.0.1:8080/
@@ -106,8 +108,10 @@ spec:
                     {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 20 }}
             serviceAccountName: {{ include "perses-operator.resourceName" (dict "suffix" "controller-manager" "context" $) }}
             terminationGracePeriodSeconds: 10
+            {{- if .Values.certManager.enable }}
             volumes:
                 - name: cert
                   secret:
                     defaultMode: 420
                     secretName: {{ include "perses-operator.resourceName" (dict "suffix" "webhook-server-cert" "context" $) }}
+            {{- end }}

--- a/charts/perses-operator/templates/tests/test-config.yaml
+++ b/charts/perses-operator/templates/tests/test-config.yaml
@@ -86,12 +86,14 @@ data:
         [ "$output" = "kube-rbac-proxy" ]
     }
 
+    {{- if .Values.certManager.enable }}
     @test "Verify webhook cert volume is mounted read-only" {
         run kubectl get pod -l control-plane=controller-manager -n {{ .Release.Namespace }} \
           -o jsonpath='{.items[0].spec.containers[0].volumeMounts[0].readOnly}'
         [ "$status" -eq 0 ]
         [ "$output" = "true" ]
     }
+    {{- end }}
 
     {{- if .Values.prometheus.enable }}
     @test "Verify that the ServiceMonitor exists" {

--- a/charts/perses-operator/unittests/manager/deployment_test.yaml
+++ b/charts/perses-operator/unittests/manager/deployment_test.yaml
@@ -149,7 +149,9 @@ tests:
           path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
           value: ALL
 
-  - it: should configure webhook cert volume as read-only from correct secret
+  - it: should configure webhook cert volume when certManager is enabled
+    set:
+      certManager.enable: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].mountPath
@@ -160,3 +162,12 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].secret.secretName
           value: test-release-perses-operator-webhook-server-cert
+
+  - it: should not mount cert volume when certManager is disabled
+    set:
+      certManager.enable: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+      - isNull:
+          path: spec.template.spec.volumes

--- a/charts/perses-operator/values.schema.json
+++ b/charts/perses-operator/values.schema.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "https://json-schema.org/schema#",
+  "type": "object",
+  "title": "Values",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "type": "object",
+      "default": {}
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "manager": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          },
+          "required": [
+            "repository",
+            "tag",
+            "pullPolicy"
+          ]
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "array"
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "image",
+        "replicas"
+      ]
+    },
+    "kubeRbacProxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "tag"
+          ]
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "image"
+      ]
+    },
+    "rbacHelpers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enable"
+      ]
+    },
+    "crd": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "keep": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enable",
+        "keep"
+      ]
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable",
+        "port"
+      ]
+    },
+    "certManager": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enable"
+      ]
+    },
+    "webhook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable",
+        "port"
+      ]
+    },
+    "prometheus": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enable"
+      ]
+    },
+    "testFramework": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "registry",
+            "repository",
+            "tag"
+          ]
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "required": [
+        "enabled",
+        "image",
+        "imagePullPolicy"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->


# Description

<!-- Context useful to a reviewer -->
Make cert-manager volume conditional and add values schema

    Fix chart installation failure when certManager.enable=false by making
    the webhook cert volume and volumeMounts conditional. Add CI test
    coverage for both cert-manager enabled and disabled paths.

Closes #164 

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
