### PR TITLE
[IGNORE] Add workflow_dispatch trigger to release workflow for manual runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - "charts/**"


### PR DESCRIPTION
We need workflow dispatch to trigger manual run release since release workflow wont be triggered unless chart/* is changed and if a failure happend and fix is done in main which didn't have chart/* files we cannot do release

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/helm-charts/blob/main/CONTRIBUTING.md
-->

# Description

<!-- What does this PR do and why? -->

Closes: #ISSUE-NUMBER

## Type of change

- [ ] `FEATURE` (new functionality)
- [ ] `ENHANCEMENT` (improves existing functionality)
- [ ] `BUGFIX` (fixes an issue)
- [ ] `BREAKINGCHANGE` (existing functionality no longer works as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] `make helm-validate` passes
- [ ] `make helm-unit-test` passes
- [ ] `make update-helm-readme` passes
- [ ] Manual testing (e.g. `make helm-test`)

## Checklist

- [x] Descriptive title following `[<catalog_entry>] <commit message>` convention
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
