### PR TITLE
[DOC] Add newline to fix list rendering

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,6 +108,7 @@ helm install my-perses perses/perses \
 ```
 
 Optional overrides:
+
 - `gateway.name` / `gateway.namespace`: name/namespace of the Gateway (defaults to `<release>-perses-gateway` in the release namespace)
 - `gateway.listeners`: listener definitions for the Gateway
 - `gateway.httpRoute.rules`: custom match/backends; defaults to PathPrefix `/` to the Perses service


### PR DESCRIPTION
# Description
The list on https://perses.dev/helm-charts/docs/installation/ rendered wrong without the newline, this should fix it.

## Type of change

- [ ] `FEATURE` (new functionality)
- [ ] `ENHANCEMENT` (improves existing functionality)
- [ ] `BUGFIX` (fixes an issue)
- [ ] `BREAKINGCHANGE` (existing functionality no longer works as expected)
- [x] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] `make helm-validate` passes
- [ ] `make helm-unit-test` passes
- [ ] `make update-helm-readme` passes
- [ ] Manual testing (e.g. `make helm-test`)

## Checklist

- [x] Descriptive title following `[<catalog_entry>] <commit message>` convention
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
