### PR TITLE
[IGNORE] ignore cert-manager.io links in mdox validation

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -8,3 +8,5 @@ validators:
   # intermittent timeouts from CI runners
   - regex: 'helm\.sh'
     type: "ignore"
+  - regex: 'cert-manager\.io'
+    type: "ignore"


### PR DESCRIPTION
External link validation against cert-manager.io intermittently fails on GitHub Actions runners due to network timeouts (status code 0: context deadline exceeded), blocking PRs unrelated to docs.

Adds cert-manager.io to the ignore list. 

link to broken GH Actions
https://github.com/perses/helm-charts/actions/runs/26561782487/job/78246881913?pr=206#step:6:114