### PR TITLE
[IGNORE]: don't fail update-docs commit step on untracked files

### DIFF
--- a/.github/workflows/update-docs-on-dependency-change.yml
+++ b/.github/workflows/update-docs-on-dependency-change.yml
@@ -34,10 +34,10 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          if [[ $(git status --porcelain) ]]; then
-            git add charts/ '*.md'
+          git add charts/ '*.md'
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
             git commit -m "chore: update generated docs"
             git push origin "${{ github.event.pull_request.head.ref }}"
-          else
-            echo "No changes to commit"
           fi


### PR DESCRIPTION
The "Update Docs and Commit" job fails on every Renovate image-update PR.

The commit step checks `git status --porcelain` to decide whether to commit, but the `perses/github-actions` setup step leaves an untracked `.github/perses-ci/` directory behind. So the check is always non-empty, `git add charts/ *.md` stages nothing, and `git commit` then exits non-zero under `bash -e` — failing the whole job even when there is nothing to regenerate.

Fix: stage the intended paths first, then use `git diff --cached --quiet` to check for actual staged changes before committing.

Example failure: https://github.com/perses/helm-charts/actions/runs/30458851250/job/90851370294?pr=222